### PR TITLE
OrderLineFieldValues column serialized as escaped text in live integr…

### DIFF
--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Dynamicweb.Ecommerce.DynamicwebLiveIntegration.csproj
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Dynamicweb.Ecommerce.DynamicwebLiveIntegration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.21.5</Version>		
+		<Version>10.21.6</Version>		
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Live Integration</Title>
 		<Description>Live Integration</Description>

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/XmlGenerators/OrderXmlGenerator.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/XmlGenerators/OrderXmlGenerator.cs
@@ -336,13 +336,7 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.XmlGenerators
             AddChildXmlNode(itemNode, "OrderLineBomItemId", orderline.BomItemId);
             AddChildXmlNode(itemNode, "OrderLineGiftCardCode", orderline.GiftCardCode);
             AddChildXmlNode(itemNode, "OrderLineIsGiftCardDiscount", (!string.IsNullOrEmpty(orderline.GiftCardCode)).ToString(), isCustomField: true);
-            var fieldValuesNode = itemNode.OwnerDocument.CreateElement("column");
-            fieldValuesNode.SetAttribute("columnName", "OrderLineFieldValues");
-            fieldValuesNode.AppendChild(
-                itemNode.OwnerDocument.ImportNode(
-                    OrderLineFieldValuesToXml(orderline.OrderLineFieldValues).DocumentElement,
-                    deep: true));
-            itemNode.AppendChild(fieldValuesNode);
+            AddChildXmlNode(itemNode, "OrderLineFieldValues", OrderLineFieldValuesToXml(orderline.OrderLineFieldValues).DocumentElement);
             if (!settings.ErpControlsDiscount && orderline.IsDiscount())
             {
                 AddChildXmlNode(itemNode, "OrderLineDiscountId", orderline.DiscountId);

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/XmlGenerators/OrderXmlGenerator.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/XmlGenerators/OrderXmlGenerator.cs
@@ -336,7 +336,13 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.XmlGenerators
             AddChildXmlNode(itemNode, "OrderLineBomItemId", orderline.BomItemId);
             AddChildXmlNode(itemNode, "OrderLineGiftCardCode", orderline.GiftCardCode);
             AddChildXmlNode(itemNode, "OrderLineIsGiftCardDiscount", (!string.IsNullOrEmpty(orderline.GiftCardCode)).ToString(), isCustomField: true);
-            AddChildXmlNode(itemNode, "OrderLineFieldValues", OrderLineFieldValuesToXml(orderline.OrderLineFieldValues).InnerXml);
+            var fieldValuesNode = itemNode.OwnerDocument.CreateElement("column");
+            fieldValuesNode.SetAttribute("columnName", "OrderLineFieldValues");
+            fieldValuesNode.AppendChild(
+                itemNode.OwnerDocument.ImportNode(
+                    OrderLineFieldValuesToXml(orderline.OrderLineFieldValues).DocumentElement,
+                    deep: true));
+            itemNode.AppendChild(fieldValuesNode);
             if (!settings.ErpControlsDiscount && orderline.IsDiscount())
             {
                 AddChildXmlNode(itemNode, "OrderLineDiscountId", orderline.DiscountId);

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/XmlGenerators/XmlGenerator.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/XmlGenerators/XmlGenerator.cs
@@ -38,6 +38,26 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.XmlGenerators
             parent.AppendChild(node);
         }
 
+        protected static void AddChildXmlNode(XmlElement parent, string nodeName, XmlNode nodeValue, bool isInformationalOnly = false, bool isCustomField = false)
+        {
+            if (parent.OwnerDocument == null)
+            {
+                throw new InvalidOperationException("Cannot call this method without an xml document associated with the parent element.");
+            }
+
+            var node = parent.OwnerDocument.CreateElement("column");
+            node.SetAttribute("columnName", nodeName);
+
+            Dictionary<string, string> attributes = BuildAttributes(isInformationalOnly, isCustomField);
+            foreach (var attribute in attributes)
+            {
+                node.SetAttribute(attribute.Key, attribute.Value);
+            }
+
+            node.AppendChild(parent.OwnerDocument.ImportNode(nodeValue, deep: true));
+            parent.AppendChild(node);
+        }
+
         /// <summary>
         /// Builds the XML document.
         /// </summary>


### PR DESCRIPTION
Observed behaviour

When the Include custom order line fields in request setting is enabled, the OrderLineFieldValues column inside the EcomOrderLines table of the outgoing order XML contains HTML-escaped text instead of proper nested XML:

<column columnName="OrderLineFieldValues"><OrderLineFieldValueCollection /></column>

The ERP receives a literal string rather than structured XML, making the field unparseable.

Expected behaviour

<column columnName="OrderLineFieldValues"> <OrderLineFieldValueCollection> <OrderLineFieldValue> <OrderLineFieldSystemName>MyField</OrderLineFieldSystemName> <Value>SomeValue</Value> </OrderLineFieldValue> </OrderLineFieldValueCollection> </column>

Root cause

The bug is in OrderXmlGenerator.cs at line 339:

AddChildXmlNode(itemNode, "OrderLineFieldValues", OrderLineFieldValuesToXml(orderline.OrderLineFieldValues).InnerXml);

OrderLineFieldValuesToXml() correctly builds an XmlDocument with proper XML nodes. .InnerXml is then called on it to extract the XML as a string. That string is passed to AddChildXmlNode(), which assigns it via:

node.InnerText = nodeValue; // XmlGenerator.cs

InnerText treats its input as plain text and XML-escapes all special characters (< → <, > → >). The result is the XML structure rendered as an escaped string rather than embedded XML nodes.

Fix

At the call site in OrderXmlGenerator.cs, bypass AddChildXmlNode and use XmlDocument.ImportNode to deep-copy the XML nodes into the parent document directly:

// Replace line 339: // AddChildXmlNode(itemNode, "OrderLineFieldValues", // OrderLineFieldValuesToXml(orderline.OrderLineFieldValues).InnerXml); var fieldValuesNode = itemNode.OwnerDocument.CreateElement("column"); fieldValuesNode.SetAttribute("columnName", "OrderLineFieldValues"); fieldValuesNode.AppendChild( itemNode.OwnerDocument.ImportNode( OrderLineFieldValuesToXml(orderline.OrderLineFieldValues).DocumentElement, deep: true)); itemNode.AppendChild(fieldValuesNode);

ImportNode copies the element tree into the target document's namespace as real XML nodes, so the output is properly structured XML rather than escaped text.