### PR TITLE
Add option to log order creation requests and responses (#28831)

### DIFF
--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Configuration/ISettings.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Configuration/ISettings.cs
@@ -129,6 +129,11 @@
         bool LogResponseErrors { get; set; }
 
         /// <summary>
+        /// Gets or sets a value that determines if order creation requests and responses should always be logged.
+        /// </summary>
+        bool LogOrderCreationRequests { get; set; }
+
+        /// <summary>
         /// Gets or sets the recipient's email address for notification emails.
         /// </summary>
         /// <value>The notification email.</value>

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Configuration/Settings.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Configuration/Settings.cs
@@ -428,6 +428,12 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.Configuration
         /// <value><c>true</c> if a copy should be saved; otherwise, <c>false</c>.</value>
         public bool SaveCopyOfOrderXml { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that determines if order creation requests and responses should always be logged,
+        /// even when general request/response logging is disabled.
+        /// </summary>
+        public bool LogOrderCreationRequests { get; set; }
+
         #endregion Logs parameters        
 
         /// <summary>
@@ -481,6 +487,7 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.Configuration
                 target.LogResponseErrors = source.LogResponseErrors;
                 target.LogGeneralErrors = source.LogGeneralErrors;
                 target.LogDebugInfo = source.LogDebugInfo;
+                target.LogOrderCreationRequests = source.LogOrderCreationRequests;
                 target.LogMaxSize = source.LogMaxSize;
                 target.KeepLogFiles = source.KeepLogFiles;
 

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Dynamicweb.Ecommerce.DynamicwebLiveIntegration.csproj
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Dynamicweb.Ecommerce.DynamicwebLiveIntegration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.21.7</Version>		
+		<Version>10.21.8</Version>		
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Live Integration</Title>
 		<Description>Live Integration</Description>

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/LiveIntegrationAddIn.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/LiveIntegrationAddIn.cs
@@ -639,6 +639,15 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration
         [AddInParameterOrder(370)]
         public bool LogDebugInfo { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that determines if order creation requests and responses should always be logged.
+        /// </summary>
+        [AddInParameter("Log order creation request and response")]
+        [AddInParameterEditor(typeof(YesNoParameterEditor), "")]
+        [AddInParameterGroup("Logs")]
+        [AddInParameterOrder(375)]
+        public bool LogOrderCreationRequests { get; set; }
+
         #endregion Logs parameters        
 
         #endregion Configuration parameters

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Logging/Logger.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Logging/Logger.cs
@@ -55,6 +55,13 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.Logging
         private bool LogDebugInfo => _settings.LogDebugInfo;
 
         /// <summary>
+        /// Set to true before an order-creation ERP call to enable per-call logging
+        /// when <see cref="Settings.LogOrderCreationRequests"/> is on but general debug
+        /// logging is off. Reset to false immediately after the call.
+        /// </summary>
+        public bool IsOrderCreationContext { get; set; }
+
+        /// <summary>
         /// Gets or sets a value that determines if general info should be logged.
         /// </summary>
         /// <value><c>true</c> if [log general errors]; otherwise, <c>false</c>.</value>
@@ -169,11 +176,11 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.Logging
             switch (level)
             {
                 case ErrorLevel.ConnectionError:
-                    result = LogConnectionErrors;
+                    result = LogConnectionErrors || (IsOrderCreationContext && _settings.LogOrderCreationRequests);
                     break;
 
                 case ErrorLevel.ResponseError:
-                    result = LogResponseErrors;
+                    result = LogResponseErrors || (IsOrderCreationContext && _settings.LogOrderCreationRequests);
                     break;
 
                 case ErrorLevel.Error:
@@ -181,7 +188,7 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration.Logging
                     break;
 
                 case ErrorLevel.DebugInfo:
-                    result = LogDebugInfo;
+                    result = LogDebugInfo || (IsOrderCreationContext && _settings.LogOrderCreationRequests);
                     break;
 
                 case ErrorLevel.EmailSend:

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/OrderHandler.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/OrderHandler.cs
@@ -137,7 +137,9 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration
 
             var ctx = new OrderResponseContext(settings, erpControlsDiscount);
 
+            logger.IsOrderCreationContext = createOrder;
             XmlDocument response = GetResponse(ctx, requestXml, order, createOrder, logger, out bool? requestCancelled, liveIntegrationSubmitType);
+            logger.IsOrderCreationContext = false;
             if (response != null && !string.IsNullOrWhiteSpace(response.InnerXml))
             {
                 bool processResponseResult = ProcessResponse(ctx, response, order, createOrder, successOrderStateId, failedOrderStateId, logger);


### PR DESCRIPTION
New 'Log order creation request and response' setting in the Logs group. When enabled, order creation ERP calls (CreateOrder=true) are always written to the log — including the request, response, connection errors, and response errors — even when general request/response logging is off.

## Summary

- Adds a new **Log order creation request and response** checkbox in the LI Logs settings group
- When enabled, all ERP communication for orders where `CreateOrder=true` is written to the log (request, response, connection errors, response errors) — independently of the general *Log request and response content* toggle
- Closes work item [#28831](https://dev.azure.com/dynamicwebsoftware/Dynamicweb/_workitems/edit/28831)

## Changes

- `Settings.cs` / `ISettings.cs` — new `LogOrderCreationRequests` property, copied in `UpdateTargetFromSource`
- `LiveIntegrationAddIn.cs` — new AddIn parameter in the Logs group (order 375)
- `Logger.cs` — `IsOrderCreationContext` flag; `IsAllowedAddToLog` passes `DebugInfo`, `ConnectionError`, and `ResponseError` when the flag is set and `LogOrderCreationRequests` is enabled
- `OrderHandler.cs` — sets `logger.IsOrderCreationContext = createOrder` before `GetResponse`, resets after

## Test plan

- [ ] Enable the new setting, disable general request/response logging — confirm only order creation calls appear in the log
- [ ] Disable the new setting — confirm no extra entries appear
- [ ] Enable both settings — confirm no double-write (each message logged once)
- [ ] Trigger a connection error on an order creation — confirm it is logged when the new setting is on
