### PR TITLE
Fix unsaved parent order line used as ParentLineId reference

### DIFF
--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Dynamicweb.Ecommerce.DynamicwebLiveIntegration.csproj
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/Dynamicweb.Ecommerce.DynamicwebLiveIntegration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.21.8</Version>		
+		<Version>10.21.9</Version>		
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Live Integration</Title>
 		<Description>Live Integration</Description>

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/OrderHandler.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/OrderHandler.cs
@@ -33,7 +33,23 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration
         /// </summary>
         private static readonly string OrderXmlLogFolder = "/Files/System/Log/LiveIntegration/OrderXml";
 
+        /// <summary>
+        /// Prefix used by OrderLine.Id for order lines that were created as part of a multi order line
+        /// request but have not actually been persisted yet. Lines with this placeholder Id still need
+        /// to be saved before they can be used as a ParentLineId reference.
+        /// </summary>
+        private const string NewMultiOrderLineIdPrefix = "DW_NEWMULTIORDERLINEID_";
+
         private readonly record struct OrderResponseContext(Settings Settings, bool ErpControlsDiscountForUser);
+
+        /// <summary>
+        /// Determines whether an order line has not actually been persisted yet, including lines whose
+        /// Id was pre-assigned a temporary multi order line placeholder before saving.
+        /// </summary>
+        private static bool IsUnsavedOrderLine(OrderLine orderLine)
+        {
+            return string.IsNullOrEmpty(orderLine.Id) || orderLine.Id.StartsWith(NewMultiOrderLineIdPrefix, StringComparison.OrdinalIgnoreCase);
+        }
 
         /// <summary>
         /// Gets the cache level for order information.
@@ -533,7 +549,7 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration
                 }
 
                 parentLine = parentLineWithVariant ?? parentLine;
-                if (parentLine != null && string.IsNullOrEmpty(parentLine.Id))
+                if (parentLine != null && IsUnsavedOrderLine(parentLine))
                 {
                     Services.OrderLines.Save(parentLine);
                     orderLineIds.Add(parentLine.Id);
@@ -723,7 +739,7 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration
                 }
 
                 parentLine = parentLineWithVariant ?? parentLine;
-                if (parentLine != null && string.IsNullOrEmpty(parentLine.Id))
+                if (parentLine != null && IsUnsavedOrderLine(parentLine))
                 {
                     Services.OrderLines.Save(parentLine);
                     orderLineIds.Add(parentLine.Id);

--- a/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/OrderHandler.cs
+++ b/src/Dynamicweb.Ecommerce.DynamicwebLiveIntegration/OrderHandler.cs
@@ -1262,7 +1262,7 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration
             {
                 return;
             }
-            var newLines = order.OrderLines.Where(l => string.IsNullOrEmpty(l.Id)).ToList();
+            var newLines = order.OrderLines.Where(IsUnsavedOrderLine).ToList();
             if (newLines.Count == 0)
             {
                 return;
@@ -1270,7 +1270,7 @@ namespace Dynamicweb.Ecommerce.DynamicwebLiveIntegration
             var mergedLines = new List<OrderLine>();
             foreach (var newLine in newLines)
             {
-                foreach (OrderLine theOrderLine in order.OrderLines.Where(l => !string.IsNullOrEmpty(l.Id)).ToList())
+                foreach (OrderLine theOrderLine in order.OrderLines.Where(l => !IsUnsavedOrderLine(l)).ToList())
                 {
                     if (!string.IsNullOrEmpty(theOrderLine.DiscountId) || theOrderLine.IsDiscount() || !theOrderLine.IsProduct())
                     {


### PR DESCRIPTION
## Summary
- `ProcessDiscountOrderLine` and `ProcessTaxOrderLine` in `OrderHandler.cs` only saved the parent order line when `parentLine.Id` was null/empty, but a not-yet-persisted `OrderLine` created as part of a multi order line request can already carry a `DW_NEWMULTIORDERLINEID_` placeholder Id.
- That meant the parent line was silently never saved, and the child discount/tax line ended up with a `ParentLineId` pointing at a non-persisted, synthetic Id.
- Added an `IsUnsavedOrderLine` helper (empty Id OR `DW_NEWMULTIORDERLINEID_` prefix, case-insensitive) and used it at both call sites so the parent line is always saved before its real Id is used.

Related work item: https://dev.azure.com/dynamicwebsoftware/Dynamicweb/_workitems/edit/29074

## Test plan
- [x] `dotnet build` succeeds with no new warnings/errors
- [ ] Manual/integration test against an ERP response containing a multi-line product + discount/tax combo to confirm the parent line is persisted and `ParentLineId` resolves to a real Id
